### PR TITLE
Make rectificationPeriod use TZ on it's generation

### DIFF
--- a/openprocurement/auctions/rubble/utils.py
+++ b/openprocurement/auctions/rubble/utils.py
@@ -148,7 +148,11 @@ def generate_rectificationPeriod(auction):
         period = type(auction).rectificationPeriod.model_class()
     period.startDate = period.startDate or now
     if not period.endDate:
-        calculated_endDate = calculate_business_date(auction.tenderPeriod.endDate, -MINIMAL_PERIOD_FROM_RECTIFICATION_END, auction)
+        calculated_endDate = TZ.localize(
+            calculate_business_date(
+                auction.tenderPeriod.endDate,
+                -MINIMAL_PERIOD_FROM_RECTIFICATION_END,
+                auction).replace(tzinfo=None))
         period.endDate = calculated_endDate if calculated_endDate > now else now
     period.invalidationDate = None
     return period


### PR DESCRIPTION
В тестах `2018-11-01` не додав, бо всі періоди генеруються динамічно, а таке хардкодження може привести до неочікуваних проблем.